### PR TITLE
Version 6.2: PHP v8.0 RC1, Redis and Zend Opcache!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v6.2.0
+
+* [2020-10-04] Upgraded to PHP v8.0 RC1.
+* [2020-10-04] Fixed the extension_dir location so PHP extensions work.
+* [2020-10-04] Installed the Zend Opcache extension.
+* [2020-10-04] Installed the PHPRedis extension.
+* [2020-10-04] Stripped out the debug symbols for massive space savings.
+* [2020-09-19] Upgraded to PHP v8.0 Beta 4.
+
+## v6.1.0: 
+
+ * [2020-09-10] Added the ability to dynamically pick what PHP version is run via $PHP_VERSION.
+ * [2020-09-10] Run the system's native PHP via $PHP_VERSION="native".
+
+## v6.0.0: 2020-09-10
+
+ * [2020-09-09] Upgraded to Ubuntu Focal Fossa v20.04-LTS.
+ * [2020-09-09] Added support for PHP v5.6.
+ * [2020-09-10] Added support for manually compiling PHP 8 pre-releases.
+
+## v5.0.2: 2020-07-17
+ * [2020-07-17] Fixed the .env.stub for Laravel DB engines.
+ 
+## v5.0.1: 2020-05-02
+ * [2020-05-02] - Fixed a bug that prevented accessing Postgres DBs via psql.
+
 ## v5.0: 2020-04-17
  * Fully automated dockerization via composer.
  * Added the ability to install specific PHP versions + DB creds.
@@ -15,6 +41,7 @@
 ## v3.0: 2020-02-26
  * Majorly refactored the build process to build all of the latest PHP versions 
    at the same time.
+ * Added the ability to dynamically pick what PHP version is run via $PHP_VERSION.
  * Added a utility to delete the web images.
  * Fixed the 'Can't locate Term/ReadLine.pm' error.
 

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -26,9 +26,9 @@ RUN apt-get update && \
                        libedit-dev libsodium-dev zlibc zlib1g zlib1g-dev \
                        libsqlite3-dev libgmp-dev libzip-dev libonig-dev && \
     #
-    curl https://downloads.php.net/~pollita/php-8.0.0beta4.tar.xz -o php.xz && \
+    curl https://downloads.php.net/~carusogabriel/php-8.0.0rc1.tar.xz -o php.xz && \
     tar xvf php.xz && \
-    cd php-8.0.0beta4 && \
+    cd php-8.0.0rc1 && \
 #    # Build CLI
     ./configure --enable-mbstring --with-pdo-mysql --with-pdo-pgsql --enable-mysqlnd \
                 --enable-gd --with-gmp --enable-bcmath --with-curl --with-zip --with-openssl \

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -58,6 +58,11 @@ RUN apt-get update && \
     cp -v ./sapi/fpm/php-fpm.conf /workdir/install/etc/php/${PHP_VERSION}/fpm/ && \
     cp -v ./sapi/fpm/www.conf     /workdir/install/etc/php/${PHP_VERSION}/fpm/pool.d && \
     #
+    ## Fix the extension_dir path (screwed up from --prefix=/workdir/install/usr):
+    echo extension_dir=$(/workdir/install/usr/bin/php --info | grep ^extension_dir | awk '{print $3}' | sed 's#/workdir/install##') >> /workdir/install/etc/php/${PHP_VERSION}/cli/php.ini && \
+    echo extension_dir=$(/workdir/install/usr/bin/php --info | grep ^extension_dir | awk '{print $3}' | sed 's#/workdir/install##') >> /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
+    sed -i 's#/workdir/install##' /workdir/install/usr/bin/phpize && \
+    #
     ## Configure PHP-FPM
     sed -i "s!display_startup_errors = Off!display_startup_errors = On!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
     sed -i "s!;error_log = php_errors.log!error_log = /proc/self/fd/2!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -63,10 +63,28 @@ RUN apt-get update && \
     echo extension_dir=$(/workdir/install/usr/bin/php --info | grep ^extension_dir | awk '{print $3}' | sed 's#/workdir/install##') >> /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
     sed -i 's#/workdir/install##' /workdir/install/usr/bin/phpize && \
     #
+    ## Install PHP so that the build programs will work.
+    cp -avf /workdir/install/* / && \
+    #
     ## Install Custom PHP Extensions
     # Zend Opcache
     echo "zend_extension=opcache" > /workdir/install/etc/php/${PHP_VERSION}/cli/conf.d/opcache.ini && \
     echo "zend_extension=opcache" > /workdir/install/etc/php/${PHP_VERSION}/fpm/conf.d/opcache.ini && \
+    # Redis
+    apt-get install -y autoconf && \
+    cd /workdir && \
+    #
+    curl -L https://github.com/phpredis/phpredis/archive/develop.zip -o phpredis.zip && \
+    unzip phpredis.zip && \
+    cd phpredis-develop && \
+    phpize && \
+    ./configure && \
+    make -j8 && \
+    make install && \
+    echo "extension=redis" > /workdir/install/etc/php/${PHP_VERSION}cli/conf.d/redis.ini && \
+    echo "extension=redis" > /workdir/install/etc/php/${PHP_VERSION}/fpm/conf.d/redis.ini && \
+    ## Install the new extensions, mostly for debug-on-build-failure.
+    cp -avf /workdir/install/* / && \
     #
     ## Configure PHP-FPM
     sed -i "s!display_startup_errors = Off!display_startup_errors = On!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
@@ -79,9 +97,10 @@ RUN apt-get update && \
     #
     sed -i "s!;catch_workers_output = yes!catch_workers_output = yes!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf && \
     sed -i "s!listen = /run/php/php${PHP_VERSION}-fpm.sock!listen = 0.0.0.0:9000!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf && \
-
+    #
     cd /workdir/install && \
-    tar czvf /workdir/php-${PHP_VERSION}-ubuntu.tar.gz *
+    tar czvf /workdir/php-${PHP_VERSION}-ubuntu.tar.gz * && \
+    echo "Finished"
 
 WORKDIR /workdir
 

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && \
                        libmysqlclient-dev libpq-dev libicu-dev libfreetype6-dev \
                        libxslt-dev libssl-dev libldb-dev libedit-dev libsodium-dev \
                        zlibc zlib1g zlib1g-dev libsqlite3-dev libgmp-dev libzip-dev \
-                       libonig-dev && \
+                       libonig-dev binutils && \
     #
     curl https://downloads.php.net/~carusogabriel/php-8.0.0rc1.tar.xz -o php.xz && \
     tar xvf php.xz && \
@@ -62,6 +62,9 @@ RUN apt-get update && \
     echo extension_dir=$(/workdir/install/usr/bin/php --info | grep ^extension_dir | awk '{print $3}' | sed 's#/workdir/install##') >> /workdir/install/etc/php/${PHP_VERSION}/cli/php.ini && \
     echo extension_dir=$(/workdir/install/usr/bin/php --info | grep ^extension_dir | awk '{print $3}' | sed 's#/workdir/install##') >> /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
     sed -i 's#/workdir/install##' /workdir/install/usr/bin/phpize && \
+    #
+    ## Strip the PHP binaries to dramatically reduce the image size (583 MB to 156 MB).
+    strip /usr/bin/php*
     #
     ## Install PHP so that the build programs will work.
     cp -avf /workdir/install/* / && \

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -1,6 +1,6 @@
 # phpexperts/php:7
 FROM ubuntu:focal as intermediate
-#FROM phpexperts/php:base
+#FROM phpexperts/php:8.0-temp
 
 ARG PHP_VERSION=8.0
 
@@ -22,19 +22,18 @@ RUN apt-get update && \
     apt-get install -y --no-install-recommends gcc g++ make && \
     apt-get install -y libxml2-dev libcurl4-openssl-dev libjpeg-dev libpng-dev \
                        libmysqlclient-dev libpq-dev libicu-dev libfreetype6-dev \
-                       libxslt-dev libssl-dev libldb-dev libmemcached-dev \
-                       libedit-dev libsodium-dev zlibc zlib1g zlib1g-dev \
-                       libsqlite3-dev libgmp-dev libzip-dev libonig-dev && \
+                       libxslt-dev libssl-dev libldb-dev libedit-dev libsodium-dev \
+                       zlibc zlib1g zlib1g-dev libsqlite3-dev libgmp-dev libzip-dev \
+                       libonig-dev && \
     #
     curl https://downloads.php.net/~carusogabriel/php-8.0.0rc1.tar.xz -o php.xz && \
     tar xvf php.xz && \
     cd php-8.0.0rc1 && \
-#    # Build CLI
+    # Build CLI
     ./configure --enable-mbstring --with-pdo-mysql --with-pdo-pgsql --enable-mysqlnd \
                 --enable-gd --with-gmp --enable-bcmath --with-curl --with-zip --with-openssl \
                 --enable-sockets --with-libedit --with-sodium --enable-exif --enable-intl \
-                --with-mysqli --with-xsl --with-zlib --with-memcache --with-memcached \
-                --prefix=/workdir/install/usr \
+                --with-mysqli --with-xsl --with-zlib --prefix=/workdir/install/usr \
                 --with-config-file-path=/etc/php/8.0/cli  --with-config-file-scan-dir=/etc/php/8.0/cli/conf.d && \
     make -j8 && \
     make install && \
@@ -42,7 +41,7 @@ RUN apt-get update && \
     ./configure --enable-mbstring --with-pdo-mysql --with-pdo-pgsql --enable-mysqlnd \
                 --enable-gd --with-gmp --enable-bcmath --with-curl --with-zip --with-openssl \
                 --enable-sockets --with-libedit --with-sodium --enable-exif --enable-intl \
-                --with-mysqli --with-xsl --with-zlib --with-memcache --with-memcached \
+                --with-mysqli --with-xsl --with-zlib \
                 --enable-fpm --with-fpm-user=www-data --enable-pcntl --prefix=/workdir/install/usr \
                 --with-config-file-path=/etc/php/8.0/fpm  --with-config-file-scan-dir=/etc/php/8.0/fpm/conf.d && \
     make -j8 && \

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -47,21 +47,12 @@ RUN apt-get update && \
     make -j8 && \
     make install && \
     #
-#    # Compile PHP extensions
-#    # PHP 8 support is broken until phpredis-5.3.2.
-#    apt install autoconf
-#    cd /workdir
-#    curl -L https://github.com/phpredis/phpredis/archive/5.3.1.tar.gz -o phpredis.tar.gz
-#    tar xvf phpredis.tar.gz
-#    cd phpredis-5.3.1/
-#    echo "done" && \
-    #
-    #
     # Fix "Unable to create the PID file (/run/php/php5.6-fpm.pid).: No such file or directory (2)"
     mkdir -p /run/php && \
     mkdir -p /workdir/install/etc/php/${PHP_VERSION}/cli/conf.d && \
     mkdir -p /workdir/install/etc/php/${PHP_VERSION}/fpm/conf.d && \
     mkdir -p /workdir/install/etc/php/${PHP_VERSION}/fpm/pool.d && \
+    cd /php-8.0.0rc1 && \
     cp -v php.ini-development /workdir/install/etc/php/${PHP_VERSION}/cli/php.ini && \
     cp -v php.ini-development /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
     cp -v ./sapi/fpm/php-fpm.conf /workdir/install/etc/php/${PHP_VERSION}/fpm/ && \

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -63,6 +63,11 @@ RUN apt-get update && \
     echo extension_dir=$(/workdir/install/usr/bin/php --info | grep ^extension_dir | awk '{print $3}' | sed 's#/workdir/install##') >> /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
     sed -i 's#/workdir/install##' /workdir/install/usr/bin/phpize && \
     #
+    ## Install Custom PHP Extensions
+    # Zend Opcache
+    echo "zend_extension=opcache" > /workdir/install/etc/php/${PHP_VERSION}/cli/conf.d/opcache.ini && \
+    echo "zend_extension=opcache" > /workdir/install/etc/php/${PHP_VERSION}/fpm/conf.d/opcache.ini && \
+    #
     ## Configure PHP-FPM
     sed -i "s!display_startup_errors = Off!display_startup_errors = On!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \
     sed -i "s!;error_log = php_errors.log!error_log = /proc/self/fd/2!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/php.ini && \


### PR DESCRIPTION
## v6.2.0

* [2020-10-04] Upgraded to PHP v8.0 RC1.
* [2020-10-04] Fixed the extension_dir location so PHP extensions work.
* [2020-10-04] Installed the Zend Opcache extension.
* [2020-10-04] Installed the PHPRedis extension.
* [2020-10-04] Stripped out the debug symbols for massive space savings.
* [2020-09-19] Upgraded to PHP v8.0 Beta 4.

## v6.1.0: 

 * [2020-09-10] Added the ability to dynamically pick what PHP version is run via $PHP_VERSION.
 * [2020-09-10] Run the system’s native PHP via $PHP_VERSION=”native”.

## v6.0.0: 2020-09-10

 * [2020-09-09] Upgraded to Ubuntu Focal Fossa v20.04-LTS.
 * [2020-09-09] Added support for PHP v5.6.
 * [2020-09-10] Added support for manually compiling PHP 8 pre-releases.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/dockerize-php/11)
<!-- Reviewable:end -->
