### PR TITLE
Version 7.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v7.1.1
 * **[2021-12-24 15:36:38 CDT]** Fixed the ability of selecting the PHP version via the .env file.
+* **[2021-12-24 16:09:02 CDT]** Upgraded to PHP v7.4.27, 8.0.14, and 8.1.1.
 
 ## v7.1.0
 * **[2021-11-18 04:10:49 CDT]** Upgraded the config files for Xdebug v3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## v7.1.1
 * **[2021-12-24 15:36:38 CDT]** Fixed the ability of selecting the PHP version via the .env file.
 * **[2021-12-24 16:09:02 CDT]** Upgraded to PHP v7.4.27, 8.0.14, and 8.1.1.
+* **[2021-12-24 16:09:16 CDT]** Added xdebug support for PHP 8.1.
 
 ## v7.1.0
 * **[2021-11-18 04:10:49 CDT]** Upgraded the config files for Xdebug v3.0.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v7.1.1
+* **[2021-12-24 15:36:38 CDT]** Fixed the ability of selecting the PHP version via the .env file.
+
 ## v7.1.0
 * **[2021-11-18 04:10:49 CDT]** Upgraded the config files for Xdebug v3.0.
 * **[2021-11-18 04:13:15 CDT]** Added the ability to configure the Docker platform via the .env.

--- a/bin/composer
+++ b/bin/composer
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 # Detect if it's running inside of docker and run it natively if it is.
 # @see https://stackoverflow.com/a/25518345/430062

--- a/bin/php
+++ b/bin/php
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
 
 # Detect if it's running inside of docker and run it natively if it is.
 # @see https://stackoverflow.com/a/25518345/430062

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -1,10 +1,8 @@
 #!/bin/bash
 
-#PHP_VERSIONS="7.4"
-#PHP_VERSIONS="5.6 7.0 7.1 7.2 7.3 7.4"
-PHP_VERSIONS="5.6 7.0 7.1 7.2 7.3 7.4 8.0"
-#HP_VERSIONS="7.0 7.1 7.2 7.3 7.4 8.0"
-#PHP_VERSIONS="8.0"
+PHP_VERSIONS="5.6 7.0 7.1 7.2 7.3 7.4 8.0 8.1"
+#PHP_VERSIONS="7.4 8.0 8.1"
+#PHP_VERSIONS="8.1"
 cd images
 
 # Build the base linux image first.

--- a/docker/images/base-php8/Dockerfile
+++ b/docker/images/base-php8/Dockerfile
@@ -16,9 +16,9 @@ RUN apt-get install -y --no-install-recommends gcc g++ make && \
                        zlibc zlib1g zlib1g-dev libsqlite3-dev libgmp-dev libzip-dev \
                        libonig-dev binutils && \
     #
-    curl https://www.php.net/distributions/php-8.1.0.tar.xz -o php.xz && \
+    curl https://www.php.net/distributions/php-8.1.1.tar.xz -o php.xz && \
     tar xvf php.xz && \
-    cd php-8.1.0 && \
+    cd php-8.1.1 && \
     # Build CLI
     ./configure --enable-mbstring --with-pdo-mysql --with-pdo-pgsql --enable-mysqlnd \
                 --enable-gd --with-gmp --enable-bcmath --with-curl --with-zip --with-openssl \
@@ -94,7 +94,7 @@ RUN echo extension_dir=$(/workdir/install/usr/bin/php --info | grep ^extension_d
     sed -i "s!listen = /run/php/php${PHP_VERSION}-fpm.sock!listen = 0.0.0.0:9000!g" /workdir/install/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf && \
     #
     cd /workdir/install && \
-    tar czvf /workdir/php-${PHP_VERSION}-ubuntu.tar.gz * && \
+    tar cvf /workdir/php-${PHP_VERSION}-ubuntu.tar * && \
     echo "Finished"
 
 WORKDIR /workdir
@@ -109,7 +109,7 @@ ARG PHP_VERSION=8.1
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 
-COPY --from=intermediate /workdir/php-8.1-ubuntu.tar.gz /php-8.1-ubuntu.tar.gz
+COPY --from=intermediate /workdir/php-8.1-ubuntu.tar /php-8.1-ubuntu.tar
 
 RUN apt-get update && \
     # Configure ondrej PPA
@@ -126,8 +126,8 @@ RUN apt-get update && \
     apt-get clean && \
 #    rm -rf /var/lib/apt/lists/* && \
     cd / && \
-    tar xvf php-8.1-ubuntu.tar.gz && \
-    rm -v php-8.1-ubuntu.tar.gz && \
+    tar xvf php-8.1-ubuntu.tar && \
+    rm -v php-8.1-ubuntu.tar && \
     echo "Finished..."
 
 WORKDIR /workdir


### PR DESCRIPTION
## v7.1.1

* **[2021-12-24 15:36:38 CDT]** Fixed the ability of selecting the PHP version via the .env file.
* **[2021-12-24 16:09:02 CDT]** Upgraded to PHP v7.4.27, 8.0.14, and 8.1.1.
* **[2021-12-24 16:09:16 CDT]** Added xdebug support for PHP 8.1.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/dockerize-php/18)
<!-- Reviewable:end -->
