### PR TITLE
Added support for composer v2.2.0+.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v7.1.2
+* **[2021-12-24 23:27:47 CDT]** Added support for composer v2.2.0+.
+
 ## v7.1.1
 * **[2021-12-24 15:36:38 CDT]** Fixed the ability of selecting the PHP version via the .env file.
 * **[2021-12-24 16:09:02 CDT]** Upgraded to PHP v7.4.27, 8.0.14, and 8.1.1.

--- a/bin/composer
+++ b/bin/composer
@@ -1,6 +1,13 @@
 #!/usr/bin/env bash
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+# @see https://linuxize.com/post/how-to-check-if-string-contains-substring-in-bash/
+# @see https://github.com/composer/composer/issues/10389
+SUB="/vendor/"
+if [[ "$0" == *"$SUB"* ]]; then
+  ROOT="$(readlink -f /proc/$PPID/cwd)"
+else
+  ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+fi
 
 # Detect if it's running inside of docker and run it natively if it is.
 # @see https://stackoverflow.com/a/25518345/430062

--- a/bin/php
+++ b/bin/php
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+# @see https://linuxize.com/post/how-to-check-if-string-contains-substring-in-bash/
+# @see https://github.com/composer/composer/issues/10389
+SUB="/vendor/"
+if [[ "$0" == *"$SUB"* ]]; then
+  ROOT="$(readlink -f /proc/$PPID/cwd)"
+else
+  ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+fi
 
 # Detect if it's running inside of docker and run it natively if it is.
 # @see https://stackoverflow.com/a/25518345/430062


### PR DESCRIPTION
The problem is that composer v2.2.0+ changed the way that vendor bin scripts are executed. Now they are executed by an intermediary shell script in a way that causes their PWD to change to the project's bin-dir, breaking project root detection.

See https://github.com/composer/composer/issues/10389

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/dockerize-php/19)
<!-- Reviewable:end -->
