### PR TITLE
Version 7.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## v7.2.0
+* **[2021-12-27 12:05:54 CDT]** Use the official PHP 8.1 builds now.
+
 ## v7.1.2
 * **[2021-12-24 23:27:47 CDT]** Added support for composer v2.2.0+.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 ## v7.2.0
 * **[2021-12-27 12:05:54 CDT]** Use the official PHP 8.1 builds now.
+* **[2021-12-27 12:06:15 CDT]** Include ext-imap and ext-ssh2.
 
 ## v7.1.2
 * **[2021-12-24 23:27:47 CDT]** Added support for composer v2.2.0+.

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -31,7 +31,7 @@ for VERSION in ${PHP_VERSIONS}; do
 
 done
 
-docker rmi --force phpexperts/php:8 phpexperts/php:8.1 phpexperts/web:nginx-php8.1
-docker build base-php8 --tag="phpexperts/php:8.1"
-
-docker build web-php8 --tag="phpexperts/web:nginx-php8.1"
+#docker rmi --force phpexperts/php:8 phpexperts/php:8.1 phpexperts/web:nginx-php8.1
+#docker build base-php8 --tag="phpexperts/php:8.1"
+#
+#docker build web-php8 --tag="phpexperts/web:nginx-php8.1"

--- a/docker/images/base/Dockerfile
+++ b/docker/images/base/Dockerfile
@@ -16,6 +16,7 @@ RUN apt-get install -y --no-install-recommends \
         php${PHP_VERSION}-gd \
         php${PHP_VERSION}-gmp \
         php${PHP_VERSION}-imagick \
+        php${PHP_VERSION}-imap \
         php${PHP_VERSION}-intl \
         php${PHP_VERSION}-mbstring \
         php${PHP_VERSION}-memcached \
@@ -23,6 +24,7 @@ RUN apt-get install -y --no-install-recommends \
         php${PHP_VERSION}-pgsql \
         php${PHP_VERSION}-opcache \
         php${PHP_VERSION}-redis \
+        php${PHP_VERSION}-ssh2 \
         php${PHP_VERSION}-soap \
         php${PHP_VERSION}-sqlite3 \
         php${PHP_VERSION}-xml \


### PR DESCRIPTION
* **[2021-12-27 12:05:54 CDT]** Use the official PHP 8.1 builds now.
* **[2021-12-27 12:06:15 CDT]** Include ext-imap and ext-ssh2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/phpexpertsinc/dockerize-php/20)
<!-- Reviewable:end -->
