### PR TITLE
Version 8.1.0

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ DB_DATABASE="rosettablog2"
 ## Docker Platform Configuration
 # Supported PHP Versions: 5.6, 7.0, 7.1, 7.2, 7.3, 7.4, 8.0, 8.1
 # Postfix it with "-debug" for xdebug support.
-PHP_VERSION="7.4-debug"
+PHP_VERSION="8.0-debug"
 # Set XDEBUG_SESSION=1 for CLI debugging support.
 XDEBUG_SESSION=0
 XDEBUG_CONFIG="idekey=PHPSTORM"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,44 +1,50 @@
+## v8.1.0
+* **[2023-07-23 03:21:22 CDT]** Now Dockerize PHP will run in the container, if it's running, or create a temp one if it's not.
+* **[2023-05-19 05:35:27 CDT]** Updated to PHP v8.0.28, v8.1.19, and v8.2.6.
+* **[2023-05-19 05:30:36 CDT]** Changed the default image from PHP v7.4 to v8.0.
+* **[2023-02-03 07:19:37 CST]** Majorly refactored so that it executes a persistent container for native launch speeds.
+
 ## v8.0.1
-* **[2023-01-20 21:58:20 CDT]** Fixed the problem that prevented the web images from being successfully built.
+* **[2023-01-20 21:58:20 CST]** Fixed the problem that prevented the web images from being successfully built.
 
 ## v8.0.0
 * **[2022-08-11 00:37:03 CDT]** Boosted the default version of PHP to 8.1.
 * **[2022-08-11 00:37:33 CDT]** Added PHP v8.2 support. master
-* **[2023-01-17 06:59:14 CDT]** Cleaned up the build script so that it tags instead of building duplicate images.
-* **[2023-01-17 07:00:57 CDT]** Improved the Linux base image build.
-* **[2023-01-17 08:46:09 CDT]** Explicitly set the default PHP version to 8.1.
-* **[2023-01-17 07:41:52 CDT]** Now, PHP will be launched from a continuously-running container for much faster runtimes at the expense of about 130 MB per container.
-* **[2023-01-17 08:57:42 CDT]** Added support for PHP 8.2.
+* **[2023-01-17 06:59:14 CST]** Cleaned up the build script so that it tags instead of building duplicate images.
+* **[2023-01-17 07:00:57 CST]** Improved the Linux base image build.
+* **[2023-01-17 08:46:09 CST]** Explicitly set the default PHP version to 8.1.
+* **[2023-01-17 07:41:52 CST]** Now, PHP will be launched from a continuously-running container for much faster runtimes at the expense of about 130 MB per container.
+* **[2023-01-17 08:57:42 CST]** Added support for PHP 8.2.
 
 ## v7.2.1
 * **[2022-06-18 00:05:57 CDT]** Show all of the output of docker build, not just the last 6 lines.
 * **[2022-06-18 00:10:05 CDT]** Upgraded to Ubuntu 22.04 Jammy Jellyfish.
 
 ## v7.2.0
-* **[2021-12-27 12:05:54 CDT]** Use the official PHP 8.1 builds now.
-* **[2021-12-27 12:06:15 CDT]** Include ext-imap and ext-ssh2.
-* **[2021-12-27 17:18:50 CDT]** (#10) Added support for the Ioncube Decoder.
-* **[2021-12-27 17:22:18 CDT]** Force the rebuilding of the Linux base image, for an up-to-date OS.
-* **[2021-12-27 17:26:25 CDT]** Added basic automated tests.
+* **[2021-12-27 12:05:54 CST]** Use the official PHP 8.1 builds now.
+* **[2021-12-27 12:06:15 CST]** Include ext-imap and ext-ssh2.
+* **[2021-12-27 17:18:50 CST]** (#10) Added support for the Ioncube Decoder.
+* **[2021-12-27 17:22:18 CST]** Force the rebuilding of the Linux base image, for an up-to-date OS.
+* **[2021-12-27 17:26:25 CST]** Added basic automated tests.
 
 ## v7.1.2
-* **[2021-12-24 23:27:47 CDT]** Added support for composer v2.2.0+.
+* **[2021-12-24 23:27:47 CST]** Added support for composer v2.2.0+.
 
 ## v7.1.1
-* **[2021-12-24 15:36:38 CDT]** Fixed the ability of selecting the PHP version via the .env file.
-* **[2021-12-24 16:09:02 CDT]** Upgraded to PHP v7.4.27, 8.0.14, and 8.1.1.
-* **[2021-12-24 16:09:16 CDT]** Added xdebug support for PHP 8.1.
+* **[2021-12-24 16:09:16 CST]** Added xdebug support for PHP 8.1.
+* **[2021-12-24 16:09:02 CST]** Upgraded to PHP v7.4.27, 8.0.14, and 8.1.1.
+* **[2021-12-24 15:36:38 CST]** Fixed the ability of selecting the PHP version via the .env file.
 
 ## v7.1.0
-* **[2021-11-18 04:10:49 CDT]** Upgraded the config files for Xdebug v3.0.
-* **[2021-11-18 04:13:15 CDT]** Added the ability to configure the Docker platform via the .env.
-* **[2021-12-10 08:32:27 CDT]** Added install support for PHP 5.6, 8.0, and 8.1.
+* **[2021-12-10 08:32:27 CST]** Added install support for PHP 5.6, 8.0, and 8.1.
+* **[2021-11-18 04:13:15 CST]** Added the ability to configure the Docker platform via the .env.
+* **[2021-11-18 04:10:49 CST]** Upgraded the config files for Xdebug v3.0.
 
 ## v7.0.0
-* **[2021-11-02 15:47:49 CDT]** PHP 8.1 RC5.
-* **[2021-11-01 08:08:36 CDT]** Dramatically reduced total build time from 33 minutes to 11 minutes.
-* **[2021-11-01 06:24:52 CDT]** Embedded composer into the php container.
-* **[2021-11-01 06:00:30 CDT]** Run the native PHP when inside docker.
+* **[2021-11-02 15:47:49 CST]** PHP 8.1 RC5.
+* **[2021-11-01 08:08:36 CST]** Dramatically reduced total build time from 33 minutes to 11 minutes.
+* **[2021-11-01 06:24:52 CST]** Embedded composer into the php container.
+* **[2021-11-01 06:00:30 CST]** Run the native PHP when inside docker.
 * **[2021-07-29 07:13:12 CDT]** Set the PHP memory_limit to unlimited by default.
 * **[2021-07-29 07:07:35 CDT]** Fixed the building of xdebug.
 * **[2021-06-21 07:10:58 CDT]** Added git and ssh for private packages supoprt.

--- a/README.md
+++ b/README.md
@@ -57,17 +57,23 @@ Ensure that your profile PATH includes `./vendor/bin` and that it takes priority
 
 ## Latest Changes
 
+## v8.1.0
+* **[2023-07-23 03:21:22 CDT]** Now Dockerize PHP will run in the container, if it's running, or create a temp one if it's not.
+* **[2023-05-19 05:35:27 CDT]** Updated to PHP v8.0.28, v8.1.19, and v8.2.6.
+* **[2023-05-19 05:30:36 CDT]** Changed the default image from PHP v7.4 to v8.0.
+* **[2023-02-03 07:19:37 CST]** Majorly refactored so that it executes a persistent container for native launch speeds.
+
 ### v8.0.1
 * **[2023-01-20 21:58:20 CDT]** Fixed the problem that prevented the web images from being successfully built.
 
 ### v8.0.0
-* **[2022-08-11 00:37:03 CDT]** Boosted the default version of PHP to 8.1.
-* **[2022-08-11 00:37:33 CDT]** Added PHP v8.2 support. master
-* **[2023-01-17 06:59:14 CDT]** Cleaned up the build script so that it tags instead of building duplicate images.
-* **[2023-01-17 07:00:57 CDT]** Improved the Linux base image build.
-* **[2023-01-17 08:46:09 CDT]** Explicitly set the default PHP version to 8.1.
-* **[2023-01-17 07:41:52 CDT]** Now, PHP will be launched from a continuously-running container for much faster runtimes at the expense of about 130 MB per container.
-* **[2023-01-17 08:57:42 CDT]** Added support for PHP 8.2.
+* **[2022-08-11 00:37:03 CST]** Boosted the default version of PHP to 8.1.
+* **[2022-08-11 00:37:33 CST]** Added PHP v8.2 support. master
+* **[2023-01-17 06:59:14 CST]** Cleaned up the build script so that it tags instead of building duplicate images.
+* **[2023-01-17 07:00:57 CST]** Improved the Linux base image build.
+* **[2023-01-17 08:46:09 CST]** Explicitly set the default PHP version to 8.1.
+* **[2023-01-17 07:41:52 CST]** Now, PHP will be launched from a continuously-running container for much faster runtimes at the expense of about 130 MB per container.
+* **[2023-01-17 08:57:42 CST]** Added support for PHP 8.2.
 
 ## Manage with docker-compose
 

--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ A utility for rapidly deploying [Docker](https://www.docker.com) for PHP apps.
 Watch the installation video: https://youtu.be/xZxaJcsbrWU
 
 Includes: 
- * PHP v7.0-7.4 + 8.0
+ * PHP v7.0-7.4 + 8.0, 8.1, 8.2
  * Nginx
  * Redis
- * PostgreSQL v12.2
+ * PostgreSQL v15
  * MariaDB v10.5
 
 # Advantages over other dockerized PHP projects

--- a/bin/php
+++ b/bin/php
@@ -35,27 +35,33 @@ if [ -z "$PHP_VERSION" ]; then
     PHP_VERSION="8.1"
 fi
 
+# Test if the network exists.
+NETWORK_STRING=""
+docker network inspect "$NETWORK_NAME" > /dev/null 2>&1
+if [ $? == 0 ]; then
+    NETWORK_STRING="--network='$NETWORK_NAME'"
+fi
+
 # Detect if the PHP container is running already...
-# If not, start it.
-if [ ! "$(docker top ${PROJECT_NAME}${PHP_VERSION} 2> /dev/null)" ]; then
-    # Test if the network exists.
-    docker network inspect $NETWORK_NAME > /dev/null 2>&1
-    if [ $? == 0 ]; then
-      docker run --name ${PROJECT_NAME}${PHP_VERSION} --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v $PWD:$PWD -v /etc/passwd:/etc/passwd:ro --network="$NETWORK_NAME" -it -v $PWD:/workdir --rm phpexperts/php:${PHP_VERSION} &
-    else
-      docker run --name ${PROJECT_NAME}${PHP_VERSION} --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v $PWD:$PWD -v /etc/passwd:/etc/passwd:ro -v $PWD:/workdir --rm -t phpexperts/php:${PHP_VERSION} &
-    fi
+# If it is running, use it directly.
+if [ "$(docker top "${PROJECT_NAME}"${PHP_VERSION} 2> /dev/null)" ]; then
+    # shellcheck disable=SC2086
+    docker run --name "${PROJECT_NAME}"${PHP_VERSION} "${NETWORK_STRING}" --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v "$PWD":$PWD -v /etc/passwd:/etc/passwd:ro -v "$PWD":/workdir --rm -t phpexperts/php:${PHP_VERSION} &
 
     # Wait for the docker process to be created.
-    while [ ! "$(docker top ${PROJECT_NAME}${PHP_VERSION} 2> /dev/null)" ]; do
+    while [ ! "$(docker top "${PROJECT_NAME}"${PHP_VERSION} 2> /dev/null)" ]; do
 #        echo "Waiting for the phpexperts_php${PHP_VERSION} container to start..."
         sleep 0.5
     done
+
+    # Run the command directly from the container for faster and more performant execution.
+    if [ "$1" == "bash" ] || [ "$1" == "composer" ]; then
+        docker exec -it "${PROJECT_NAME}"${PHP_VERSION} "$@"
+    else
+        docker exec -it "${PROJECT_NAME}"${PHP_VERSION} php "$@"
+    fi
+
+    exit
 fi
 
-# Run the command directly from the container for faster and more performant execution.
-if [ "$1" == "bash" ] || [ "$1" == "composer" ]; then
-    docker exec -it ${PROJECT_NAME}${PHP_VERSION} "$@"
-else
-    docker exec -it ${PROJECT_NAME}${PHP_VERSION} php "$@"
-fi
+docker run "${NETWORK_STRING}" --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v "$PWD":"$PWD" -v /etc/passwd:/etc/passwd:ro -v "$PWD":/workdir --rm -it phpexperts/php:${PHP_VERSION} "$@"

--- a/bin/php
+++ b/bin/php
@@ -6,7 +6,7 @@ SUB="/vendor/"
 if [[ "$0" == *"$SUB"* ]]; then
   ROOT="$(readlink -f /proc/$PPID/cwd)"
 else
-  ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/../.." && pwd )"
+  ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 fi
 
 # Detect if it's running inside of docker and run it natively if it is.
@@ -37,17 +37,17 @@ fi
 
 # Detect if the PHP container is running already...
 # If not, start it.
-if [ ! "$(docker top phpexperts_php${PHP_VERSION} 2> /dev/null)" ]; then
+if [ ! "$(docker top ${PROJECT_NAME}${PHP_VERSION} 2> /dev/null)" ]; then
     # Test if the network exists.
     docker network inspect $NETWORK_NAME > /dev/null 2>&1
     if [ $? == 0 ]; then
-      docker run --name phpexperts_php${PHP_VERSION} --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v $PWD:$PWD -v /etc/passwd:/etc/passwd:ro --network="$NETWORK_NAME" -it -v $PWD:/workdir --rm phpexperts/php:${PHP_VERSION} &
+      docker run --name ${PROJECT_NAME}${PHP_VERSION} --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v $PWD:$PWD -v /etc/passwd:/etc/passwd:ro --network="$NETWORK_NAME" -it -v $PWD:/workdir --rm phpexperts/php:${PHP_VERSION} &
     else
-      docker run --name phpexperts_php${PHP_VERSION} --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v $PWD:$PWD -v /etc/passwd:/etc/passwd:ro -v $PWD:/workdir --rm -t phpexperts/php:${PHP_VERSION} &
+      docker run --name ${PROJECT_NAME}${PHP_VERSION} --env XDEBUG_SESSION --env XDEBUG_CONFIG -u=$UID -v $HOME:$HOME -v $PWD:$PWD -v /etc/passwd:/etc/passwd:ro -v $PWD:/workdir --rm -t phpexperts/php:${PHP_VERSION} &
     fi
 
     # Wait for the docker process to be created.
-    while [ ! "$(docker top phpexperts_php${PHP_VERSION} 2> /dev/null)" ]; do
+    while [ ! "$(docker top ${PROJECT_NAME}${PHP_VERSION} 2> /dev/null)" ]; do
 #        echo "Waiting for the phpexperts_php${PHP_VERSION} container to start..."
         sleep 0.5
     done
@@ -55,7 +55,7 @@ fi
 
 # Run the command directly from the container for faster and more performant execution.
 if [ "$1" == "bash" ] || [ "$1" == "composer" ]; then
-    docker exec -it phpexperts_php${PHP_VERSION} "$@"
+    docker exec -it ${PROJECT_NAME}${PHP_VERSION} "$@"
 else
-    docker exec -it phpexperts_php${PHP_VERSION} php "$@"
+    docker exec -it ${PROJECT_NAME}${PHP_VERSION} php "$@"
 fi

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -36,8 +36,8 @@ for VERSION in ${PHP_VERSIONS}; do
 #  docker build full       --tag="phpexperts/php:${VERSION}-full"           --build-arg PHP_VERSION=$VERSION --no-cache --progress=plain
 
   docker build base-debug --tag="phpexperts/php:latest-debug"              --build-arg PHP_VERSION=$VERSION --no-cache --progress=plain
-  docker tag phpexperts/php:latest "phpexperts/php:${MAJOR_VERSION}-debug"
-  docker tag phpexperts/php:latest "phpexperts/php:${VERSION}-debug"
+  docker tag phpexperts/php:latest-debug "phpexperts/php:${MAJOR_VERSION}-debug"
+  docker tag phpexperts/php:latest-debug "phpexperts/php:${VERSION}-debug"
 
   docker tag "phpexperts/php:${VERSION}" phpexperts/php:latest
   docker build web        --tag="phpexperts/web:nginx-php${VERSION}"       --build-arg PHP_VERSION=$VERSION --no-cache --progress=plain

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -13,7 +13,7 @@ export DOCKER_BUILDKIT=1
 docker rmi --force phpexperts/linux:latest
 docker build linux --tag="phpexperts/linux:latest" --no-cache --progress=plain
 docker tag phpexperts/linux:latest phpexperts/linux:$(date '+%Y-%m-%d')
-
+exit
 for VERSION in ${PHP_VERSIONS}; do
   MAJOR_VERSION=${VERSION%.*}
 

--- a/docker/build-images.sh
+++ b/docker/build-images.sh
@@ -13,7 +13,7 @@ export DOCKER_BUILDKIT=1
 docker rmi --force phpexperts/linux:latest
 docker build linux --tag="phpexperts/linux:latest" --no-cache --progress=plain
 docker tag phpexperts/linux:latest phpexperts/linux:$(date '+%Y-%m-%d')
-exit
+
 for VERSION in ${PHP_VERSIONS}; do
   MAJOR_VERSION=${VERSION%.*}
 

--- a/docker/images/base-debug/Dockerfile
+++ b/docker/images/base-debug/Dockerfile
@@ -1,7 +1,7 @@
 # phpexperts/php:7-base-debug
 FROM phpexperts/php:latest
 
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 
 COPY xdebug.conf /tmp
 

--- a/docker/images/base-ioncube/Dockerfile
+++ b/docker/images/base-ioncube/Dockerfile
@@ -1,6 +1,6 @@
 # phpexperts/php:7-base-debug
 
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 FROM phpexperts/php:${PHP_VERSION}
 
 ARG PHP_VERSION

--- a/docker/images/base/Dockerfile
+++ b/docker/images/base/Dockerfile
@@ -1,11 +1,14 @@
 # phpexperts/php:7
 FROM phpexperts/linux:latest
 
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 
 # Fix add-apt-repository is broken with non-UTF-8 locales, see https://github.com/oerdnj/deb.sury.org/issues/56
 ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
+
+## Change the mirror to Turkey, because I'm in UAE right now and it's damn slow.
+RUN sed -i -e 's#http://archive.ubuntu.com/ubuntu/#https://mirror.alastyr.com/ubuntu/ubuntu-archive/#' /etc/apt/sources.list
 
 RUN apt-get install -y --no-install-recommends \
         php${PHP_VERSION}-cli \

--- a/docker/images/base/Dockerfile
+++ b/docker/images/base/Dockerfile
@@ -8,7 +8,7 @@ ENV LC_ALL C.UTF-8
 ENV DEBIAN_FRONTEND noninteractive
 
 ## Change the mirror to Turkey, because I'm in UAE right now and it's damn slow.
-RUN sed -i -e 's#http://archive.ubuntu.com/ubuntu/#https://mirror.alastyr.com/ubuntu/ubuntu-archive/#' /etc/apt/sources.list
+#RUN sed -i -e 's#http://archive.ubuntu.com/ubuntu/#https://mirror.alastyr.com/ubuntu/ubuntu-archive/#' /etc/apt/sources.list
 
 RUN apt-get install -y --no-install-recommends \
         php${PHP_VERSION}-cli \

--- a/docker/images/linux/Dockerfile
+++ b/docker/images/linux/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:jammy
 ENV LANG=C.UTF-8 \ LC_ALL=C.UTF-8 \ DEBIAN_FRONTEND=noninteractive
 
 ## Change the mirror to Turkey, because I'm in UAE right now and it's damn slow.
-RUN sed -i -e 's#http://archive.ubuntu.com/ubuntu/#https://mirror.alastyr.com/ubuntu/ubuntu-archive/#' /etc/apt/sources.list
+#RUN sed -i -e 's#http://archive.ubuntu.com/ubuntu/#https://mirror.alastyr.com/ubuntu/ubuntu-archive/#' /etc/apt/sources.list
 
 RUN echo "Building base Linux..." && \
     apt-get update -y && \

--- a/docker/images/linux/Dockerfile
+++ b/docker/images/linux/Dockerfile
@@ -3,6 +3,9 @@ FROM ubuntu:jammy
 # Fix add-apt-repository is broken with non-UTF-8 locales, see https://github.com/oerdnj/deb.sury.org/issues/56
 ENV LANG=C.UTF-8 \ LC_ALL=C.UTF-8 \ DEBIAN_FRONTEND=noninteractive
 
+## Change the mirror to Turkey, because I'm in UAE right now and it's damn slow.
+RUN sed -i -e 's#http://archive.ubuntu.com/ubuntu/#https://mirror.alastyr.com/ubuntu/ubuntu-archive/#' /etc/apt/sources.list
+
 RUN echo "Building base Linux..." && \
     apt-get update -y && \
     # Configure ondrej PPA

--- a/docker/images/web-debug/Dockerfile
+++ b/docker/images/web-debug/Dockerfile
@@ -1,5 +1,5 @@
 # phpexperts/web-debug
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 FROM phpexperts/php:${PHP_VERSION}-debug
 ARG PHP_VERSION
 

--- a/docker/images/web-ioncube/Dockerfile
+++ b/docker/images/web-ioncube/Dockerfile
@@ -1,5 +1,5 @@
 # phpexperts/web-debug
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 FROM phpexperts/php:${PHP_VERSION}-ioncube
 ARG PHP_VERSION
 

--- a/docker/images/web/Dockerfile
+++ b/docker/images/web/Dockerfile
@@ -1,5 +1,5 @@
 # phpexperts/web
-ARG PHP_VERSION=7.4
+ARG PHP_VERSION=8.0
 FROM phpexperts/php:$PHP_VERSION
 ARG PHP_VERSION
 


### PR DESCRIPTION
* **[2023-07-23 03:21:22 CDT]** Now Dockerize PHP will run in the container, if it's running, or create a temp one if it's not.
* **[2023-05-19 05:35:27 CDT]** Updated to PHP v8.0.28, v8.1.19, and v8.2.6.
* **[2023-05-19 05:30:36 CDT]** Changed the default image from PHP v7.4 to v8.0.
* **[2023-02-03 07:19:37 CST]** Majorly refactored so that it executes a persistent container for native launch speeds.
